### PR TITLE
feat: Add parameterization for TLS InsecureSkipVerify 

### DIFF
--- a/docs/SELFHOSTING.md
+++ b/docs/SELFHOSTING.md
@@ -46,6 +46,7 @@ options.
 
 	server_addr: example.com:4443
 	trust_host_root_certs: true
+	use_insecure_skip_verify: false
 
 Substitute the address of your ngrokd server for "example.com:4443". The "trust_host_root_certs" parameter instructs
 ngrok to trust the root certificates on your computer when establishing TLS connections to the server. By default, ngrok
@@ -62,6 +63,7 @@ If you do choose to use a self-signed cert, please note that you must either rem
 trust_host_root_certs or set it to false:
 
     trust_host_root_certs: false
+	use_insecure_skip_verify: true
 
 Special thanks @kk86bioinfo, @lyoshenka and everyone in the thread https://github.com/inconshreveable/ngrok/issues/84 for help in writing up instructions on how to do it:
 

--- a/docs/SELFHOSTING.md
+++ b/docs/SELFHOSTING.md
@@ -30,13 +30,13 @@ You'll run the server with the following command.
 ngrok only makes TLS-encrypted connections. When you run ngrokd, you'll need to instruct it
 where to find your TLS certificate and private key. Specify the paths with the following switches:
 
-	-tlsKey="/path/to/tls.key" -tlsCrt="/path/to/tls.crt"
+    -tlsKey="/path/to/tls.key" -tlsCrt="/path/to/tls.crt"
 
 ### Setting the server's domain
 When you run your own ngrokd server, you need to tell ngrokd the domain it's running on so that it
 knows what URLs to issue to clients.
 
-	-domain="example.com"
+    -domain="example.com"
 
 ## 5. Configure the client
 In order to connect with a client, you'll need to set two options in ngrok's configuration file.
@@ -44,9 +44,9 @@ The ngrok configuration file is a simple YAML file that is read from ~/.ngrok by
 a custom configuration file path with the -config switch. Your config file must contain the following two
 options.
 
-	server_addr: example.com:4443
-	trust_host_root_certs: true
-	use_insecure_skip_verify: false
+    server_addr: example.com:4443
+    trust_host_root_certs: true
+    use_insecure_skip_verify: false
 
 Substitute the address of your ngrokd server for "example.com:4443". The "trust_host_root_certs" parameter instructs
 ngrok to trust the root certificates on your computer when establishing TLS connections to the server. By default, ngrok
@@ -63,7 +63,7 @@ If you do choose to use a self-signed cert, please note that you must either rem
 trust_host_root_certs or set it to false:
 
     trust_host_root_certs: false
-	use_insecure_skip_verify: true
+    use_insecure_skip_verify: true
 
 Special thanks @kk86bioinfo, @lyoshenka and everyone in the thread https://github.com/inconshreveable/ngrok/issues/84 for help in writing up instructions on how to do it:
 

--- a/pkg/client/config.go
+++ b/pkg/client/config.go
@@ -2,8 +2,6 @@ package client
 
 import (
 	"fmt"
-	"github.com/traefix/ngrok2/pkg/log"
-	"gopkg.in/yaml.v1"
 	"io/ioutil"
 	"net"
 	"net/url"
@@ -13,17 +11,21 @@ import (
 	"regexp"
 	"strconv"
 	"strings"
+
+	"github.com/traefix/ngrok2/pkg/log"
+	"gopkg.in/yaml.v1"
 )
 
 type Configuration struct {
-	HttpProxy          string                          `yaml:"http_proxy,omitempty"`
-	ServerAddr         string                          `yaml:"server_addr,omitempty"`
-	InspectAddr        string                          `yaml:"inspect_addr,omitempty"`
-	TrustHostRootCerts bool                            `yaml:"trust_host_root_certs,omitempty"`
-	AuthToken          string                          `yaml:"auth_token,omitempty"`
-	Tunnels            map[string]*TunnelConfiguration `yaml:"tunnels,omitempty"`
-	LogTo              string                          `yaml:"-"`
-	Path               string                          `yaml:"-"`
+	HttpProxy             string                          `yaml:"http_proxy,omitempty"`
+	ServerAddr            string                          `yaml:"server_addr,omitempty"`
+	InspectAddr           string                          `yaml:"inspect_addr,omitempty"`
+	TrustHostRootCerts    bool                            `yaml:"trust_host_root_certs,omitempty"`
+	AuthToken             string                          `yaml:"auth_token,omitempty"`
+	Tunnels               map[string]*TunnelConfiguration `yaml:"tunnels,omitempty"`
+	LogTo                 string                          `yaml:"-"`
+	Path                  string                          `yaml:"-"`
+	UseInsecureSkipVerify bool                            `yaml:"use_insecure_skip_verify,omitempty"` // New field added
 }
 
 type TunnelConfiguration struct {

--- a/pkg/client/model.go
+++ b/pkg/client/model.go
@@ -3,6 +3,14 @@ package client
 import (
 	"crypto/tls"
 	"fmt"
+	"io/ioutil"
+	"math"
+	"net"
+	"runtime"
+	"strings"
+	"sync/atomic"
+	"time"
+
 	metrics "github.com/rcrowley/go-metrics"
 	"github.com/traefix/ngrok2/pkg/client/mvc"
 	"github.com/traefix/ngrok2/pkg/conn"
@@ -11,13 +19,6 @@ import (
 	"github.com/traefix/ngrok2/pkg/proto"
 	"github.com/traefix/ngrok2/pkg/util"
 	"github.com/traefix/ngrok2/version"
-	"io/ioutil"
-	"math"
-	"net"
-	"runtime"
-	"strings"
-	"sync/atomic"
-	"time"
 )
 
 const (
@@ -115,7 +116,11 @@ func newClientModel(config *Configuration, ctl mvc.Controller) *ClientModel {
 
 	// configure TLS SNI
 	m.tlsConfig.ServerName = serverName(m.serverAddr)
-	m.tlsConfig.InsecureSkipVerify = useInsecureSkipVerify()
+	if config.UseInsecureSkipVerify {
+		m.tlsConfig.InsecureSkipVerify = true
+	} else {
+		m.tlsConfig.InsecureSkipVerify = false
+	}
 
 	return m
 }


### PR DESCRIPTION
- Updated the `Configuration` struct to include a `UseInsecureSkipVerify` field.
- Modified the `newClientModel` function to set `tlsConfig.InsecureSkipVerify` based on the `UseInsecureSkipVerify` configuration.
- Ensured default behavior by setting `InsecureSkipVerify` to `false` if the configuration is not explicitly set to `true`.
- Updated documentation to reflect the new configuration option for `UseInsecureSkipVerify`.